### PR TITLE
Change anchor name for 'High Scores Saving' section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2680,7 +2680,7 @@
 
   <br>
   <p><h2>
-  <a name="Highscores">High Scores Saving</a></h2>
+  <a name="HighScores">High Scores Saving</a></h2>
   <blockquote>
 
   <p>Stella allows the user to save high scores when the required definitions


### PR DESCRIPTION
Some browsers treat anchor names case-sensitively. The anchor name for the 'High Scores Saving' section has a lower case 'S' meaning that the links to that section (eg from the table of contents) do not work. This patch chages the anchor name from "Highscores" to "HighScores"